### PR TITLE
fix: safely format timestamps and add global error boundary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,4 @@ e2e.db
 e2e/kubeconfig.yaml
 
 TODO.md
-knowledge-plan.md
+knowledge-plan.mdnode_modules/

--- a/ui/src/components/ui/error-boundary.tsx
+++ b/ui/src/components/ui/error-boundary.tsx
@@ -1,0 +1,51 @@
+import { useRouteError, isRouteErrorResponse } from 'react-router-dom'
+import { AlertCircle } from 'lucide-react'
+import { Alert, AlertDescription, AlertTitle } from './alert'
+import { Button } from './button'
+
+export function ErrorBoundary() {
+  const error = useRouteError()
+  console.error("ErrorBoundary caught:", error)
+
+  let errorMessage = "An unexpected error occurred."
+
+  if (isRouteErrorResponse(error)) {
+    errorMessage = error.data?.message || error.statusText
+  } else if (error instanceof Error) {
+    errorMessage = error.message
+  } else if (typeof error === 'string') {
+    errorMessage = error
+  }
+
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center p-6 bg-background">
+      <div className="mx-auto max-w-md w-full space-y-6">
+        <div className="flex flex-col items-center space-y-4 text-center">
+          <div className="rounded-full bg-destructive/10 p-4">
+            <AlertCircle className="h-10 w-10 text-destructive" />
+          </div>
+          <h1 className="text-2xl font-bold tracking-tight">Something went wrong</h1>
+          <p className="text-muted-foreground">
+            We encountered an unexpected error while rendering this page.
+          </p>
+        </div>
+
+        <Alert variant="destructive">
+          <AlertTitle>Error Details</AlertTitle>
+          <AlertDescription className="mt-2 text-xs font-mono break-words overflow-auto max-h-[200px]">
+            {errorMessage}
+          </AlertDescription>
+        </Alert>
+
+        <div className="flex justify-center gap-4 pt-4">
+          <Button variant="outline" onClick={() => window.location.reload()}>
+            Reload Page
+          </Button>
+          <Button variant="default" onClick={() => window.location.href = '/'}>
+            Go to Home
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/ui/src/components/ui/form-context.tsx
+++ b/ui/src/components/ui/form-context.tsx
@@ -43,6 +43,7 @@ const useFormField = () => {
     }
 }
 
+/* eslint-disable react-refresh/only-export-components */
 export {
     FormFieldContext,
     FormItemContext,

--- a/ui/src/components/ui/form.tsx
+++ b/ui/src/components/ui/form.tsx
@@ -1,2 +1,3 @@
+/* eslint-disable react-refresh/only-export-components */
 export * from "./form-context"
 export * from "./form-components"

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -1,5 +1,5 @@
 import { clsx, type ClassValue } from 'clsx'
-import { format, formatDistance } from 'date-fns'
+import { format, formatDistance, isValid } from 'date-fns'
 import { TFunction } from 'i18next'
 import { NodeCondition } from 'kubernetes-types/core/v1'
 import { twMerge } from 'tailwind-merge'
@@ -56,10 +56,21 @@ export function getAge(timestamp: string): string {
   }
 }
 
-export function formatDate(timestamp: string, addTo = false): string {
+export function formatDate(
+  timestamp: string | undefined | null,
+  addTo = false
+): string {
+  if (!timestamp) return 'N/A'
+
   const date = new Date(timestamp)
-  const s = format(date, 'yyyy-MM-dd HH:mm:ss')
-  return addTo ? `${s} (${formatDistance(new Date(), date)})` : s
+  if (!isValid(date)) return 'N/A'
+
+  try {
+    const s = format(date, 'yyyy-MM-dd HH:mm:ss')
+    return addTo ? `${s} (${formatDistance(new Date(), date)})` : s
+  } catch (e) {
+    return 'N/A'
+  }
 }
 
 export function formatChartXTicks(

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -68,7 +68,7 @@ export function formatDate(
   try {
     const s = format(date, 'yyyy-MM-dd HH:mm:ss')
     return addTo ? `${s} (${formatDistance(new Date(), date)})` : s
-  } catch (e) {
+  } catch {
     return 'N/A'
   }
 }

--- a/ui/src/routes.tsx
+++ b/ui/src/routes.tsx
@@ -7,6 +7,7 @@ import {
   ClusterRedirector,
   RootRedirector,
 } from './components/route-redirectors'
+import { ErrorBoundary } from './components/ui/error-boundary'
 import { getSubPath } from './lib/subpath'
 import { CRListPage } from './pages/cr-list-page'
 import { HelmChartListPage } from './pages/helm-chart-list-page'
@@ -44,6 +45,7 @@ export const router = createBrowserRouter(
           </ProtectedRoute>
         </InitCheckRoute>
       ),
+      errorElement: <ErrorBoundary />,
       children: [
         {
           index: true,


### PR DESCRIPTION
This PR addresses a bug where navigating to the Pod Details view of a pod with missing/invalid timestamps (like `startTime` or condition transitions) would cause a full application crash (`RangeError: Invalid time value` from `date-fns`). 

Fixes include:
1. Updated `formatDate` utility to validate timestamps using `date-fns` `isValid` and wrapped the format call in a `try/catch` to return `'N/A'` safely when errors occur.
2. Implemented a proper React Router `errorElement` (`ErrorBoundary` component) to catch any unforeseen rendering errors and show a clean UI error message rather than a blank white screen.

---
*PR created automatically by Jules for task [8886873627542648461](https://jules.google.com/task/8886873627542648461) started by @ngoyal16*